### PR TITLE
Hdmi support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+dist/
+external/
+kernel/
+buildroot/dl/
+buildroot/output/

--- a/buildroot/board/rockchip/rk3128h/fs-overlay/etc/init.d/S50launcher
+++ b/buildroot/board/rockchip/rk3128h/fs-overlay/etc/init.d/S50launcher
@@ -5,28 +5,47 @@
 
 case "$1" in
   start)
-		printf "Starting launcher: "
-		export LC_ALL='en_US.utf8'
+    printf "Starting launcher: "
+    export LC_ALL='en_US.utf8'
 
-		export WESTON_DRM_MIRROR=0
-		export WESTON_DRM_PREFER_EXTERNAL=1
+    export WESTON_DRM_MIRROR=0
+    export WESTON_DRM_PREFER_EXTERNAL=1
 
-		#for QLauncher wayland
-		mkdir -p /tmp/.xdg &&  chmod 0700 /tmp/.xdg
-		export XDG_RUNTIME_DIR=/tmp/.xdg
-		weston --tty=2 --idle-time=0&
-		/usr/local/share/scripts/bc.sh
-		export HOME=/userdata/system
-		emulationstation &
-#		retroarch -c /sdcard/settings/retroarch/retroarch.cfg &
-	;;
+    # for QLauncher wayland
+    mkdir -p /tmp/.xdg &&  chmod 0700 /tmp/.xdg
+    export XDG_RUNTIME_DIR=/tmp/.xdg
+    weston --tty=2 --idle-time=0 &
+
+    # start brightness control
+    /usr/local/share/scripts/bc.sh
+
+    # select display, appropriate resolution and sound path
+    if [ `cat /sys/class/drm/card0-HDMI-A-1/status` == "connected" ]; then
+      ra_config="/sdcard/settings/retroarch/retroarch_hdmi.cfg"
+      amixer cset name='Playback Path' 'OFF'
+
+    else
+      case `cat /sys/class/drm/card0-LVDS-1/mode` in
+        1024x600*)
+          ra_config="/sdcard/settings/retroarch/retroarch.cfg" ;;
+        800x480*)
+          ra_config="/sdcard/settings/retroarch/retroarchi_v3.cfg" ;;
+      esac
+      amixer cset name='Playback Path' 'SPK'
+
+    fi
+
+    echo ${ra_config} >> /sdcard/config.log
+    sync
+    retroarch -c ${ra_config} &
+    ;;
   stop)
-		killall weston
-		printf "stop finished"
-        ;;
+    killall weston
+    printf "stop finished"
+    ;;
   *)
-        echo "Usage: $0 {start|stop}"
-        exit 1
-        ;;
+    echo "Usage: $0 {start|stop}"
+    exit 1
+    ;;
 esac
 exit 0

--- a/buildroot/board/rockchip/rk3128h/fs-overlay/etc/xdg/weston/weston.ini
+++ b/buildroot/board/rockchip/rk3128h/fs-overlay/etc/xdg/weston/weston.ini
@@ -1,0 +1,54 @@
+[core]
+backend=drm-backend.so
+
+# Allow running without input devices
+require-input=false
+
+# Disable screen idle timeout by default
+idle-time=0
+
+# 1. The repaint window should be longer than the compositor's repaint time to
+#    avoid missing the very next vblank.
+# 2. The repaint delay(frame period - repaint window) should be longer than
+#    the client's repaint time in the Presentation case.
+# 3. The repaint window should be as small as possible to reduce the display
+#    latency.
+repaint-window=15
+
+# Allow blending with lower drm planes
+# gbm-format=argb8888
+
+[shell]
+# top(default)|bottom|left|right|none, none to disable panel
+panel-position=none
+background-color=0xff000000
+
+# none|minutes(default)|seconds
+# clock-format=seconds
+
+# Disable screen locking
+locking=false
+
+[libinput]
+# Uncomment below to enable touch screen calibrator(weston-touch-calibrator)
+# touchscreen_calibrator=true
+# calibration_helper=/bin/weston-calibration-helper.sh
+
+[keyboard]
+# Comment this to enable vt switching
+vt-switching=false
+
+# Configs for auto key repeat
+# repeat-rate=40
+# repeat-delay=400
+
+# Internal display, set preferred mode as V3 has a diffeent display
+[output]
+name=LVDS-1
+mode=preferred
+
+# HDMI ouput is forced to 720p for performance and also to keep it
+# aligned with the retroarch configuration
+[output]
+name=HDMI-A-1
+mode=1280x720@60


### PR DESCRIPTION
This change checks whether the HDMI cable is plugged or not
and starts RetroArch with the corresponding configuration
(display resolution and audio device must be set via
retroarch.cfg). The retroarch config file is selected
based on the current display resolution, and supports
HDMI (720p) and internal displays for powkiddy v2 and v3.

Weston is configured to support the internal display and
HDMI at 720p@60.

Audio path is also properly set. It's worth noting that HDMI
audio output is 'hw:0,1', so RetroArch should be configured
accordingly.

As a side change, I've updated the ignore list to clean the status of the local repository. I can remove that commit from this PR and create a separate one if needed.