### PR TITLE
Add sync mount option and call poweroff on exit RA

### DIFF
--- a/buildroot/board/rockchip/rk3128h/fs-overlay/etc/fstab
+++ b/buildroot/board/rockchip/rk3128h/fs-overlay/etc/fstab
@@ -1,0 +1,13 @@
+# <file system>			<mount pt>		<type>		<options>		<dump>	<pass>
+/dev/root			/			ext2		rw,noauto		0	1
+proc				/proc			proc		defaults		0	0
+devpts				/dev/pts		devpts		defaults,gid=5,mode=620	0	0
+tmpfs				/dev/shm		tmpfs		mode=0777		0	0
+tmpfs				/tmp			tmpfs		mode=1777		0	0
+tmpfs				/run			tmpfs		mode=0755,nosuid,nodev	0	0
+sysfs				/sys			sysfs		defaults		0	0
+debug				/sys/kernel/debug	debugfs		defaults		0	0
+pstore				/sys/fs/pstore		pstore		defaults		0	0
+/dev/block/by-name/misc		/misc			emmc		defaults		0	0
+/dev/block/by-name/oem		/oem			squashfs		defaults		0	2
+/dev/block/by-name/userdata	/userdata		ext2		sync		0	2

--- a/buildroot/board/rockchip/rk3128h/fs-overlay/etc/init.d/S50launcher
+++ b/buildroot/board/rockchip/rk3128h/fs-overlay/etc/init.d/S50launcher
@@ -35,9 +35,7 @@ case "$1" in
 
     fi
 
-    echo ${ra_config} >> /sdcard/config.log
-    sync
-    retroarch -c ${ra_config} &
+    ( retroarch -c ${ra_config}; poweroff; ) &
     ;;
   stop)
     killall weston

--- a/buildroot/board/rockchip/rk3128h/fs-overlay/lib/udev/rules.d/61-sd-cards-auto-mount.rules
+++ b/buildroot/board/rockchip/rk3128h/fs-overlay/lib/udev/rules.d/61-sd-cards-auto-mount.rules
@@ -1,0 +1,34 @@
+KERNEL!="mmcblk*[0-9]", GOTO="sd_cards_auto_mount_end"
+SUBSYSTEM!="block", GOTO="sd_cards_auto_mount_end"
+ACTION=="add", PROGRAM!="/sbin/blkid %N", GOTO="sd_cards_auto_mount_end"
+ATTRS{type}!="SD", GOTO="sd_cards_auto_mount_end"
+
+IMPORT{program}="/sbin/blkid -o udev -p %N"
+
+ACTION=="add", ENV{mount_options_vfat}="rw,uid=1000,gid=1000,dmask=022,fmask=133,noatime,sync"
+
+ACTION=="add", ENV{ID_FS_TYPE}=="vfat", RUN+="/bin/mount -t vfat -o %E{mount_options_vfat} /dev/%k '/mnt/sdcard'"
+
+ACTION=="add", ENV{mount_options_ntfs}="rw,uid=1000,gid=1000,dmask=022,fmask=133,noatime,sync"
+
+ACTION=="add", ENV{ID_FS_TYPE}=="ntfs", RUN+="/bin/mount -t ntfs-3g -o %E{mount_options_ntfs} /dev/%k '/mnt/sdcard'"
+
+ACTION=="add", ENV{mount_options_exfat}="rw,uid=1000,gid=1000,dmask=022,fmask=133,noatime,sync"
+
+ACTION=="add", ENV{ID_FS_TYPE}=="exfat", RUN+="/bin/mount -t exfat-fuse -o %E{mount_options_exfat} /dev/%k '/mnt/sdcard'"
+
+ACTION=="add", ENV{mount_options_ext2}="exec,noatime,sync"
+
+ACTION=="add", ENV{ID_FS_TYPE}=="ext2", RUN+="/bin/mount -t ext2 -o %E{mount_options_ext2} /dev/%k '/mnt/sdcard'"
+
+ACTION=="add", ENV{mount_options_ext3}="exec,noatime,sync"
+
+ACTION=="add", ENV{ID_FS_TYPE}=="ext3", RUN+="/bin/mount -t ext3 -o %E{mount_options_ext3} /dev/%k '/mnt/sdcard'"
+
+ACTION=="add", ENV{mount_options_ext4}="exec,noatime,sync"
+
+ACTION=="add", ENV{ID_FS_TYPE}=="ext4", RUN+="/bin/mount -t ext4 -o %E{mount_options_ext4} /dev/%k '/mnt/sdcard'"
+
+ACTION=="remove", RUN+="/bin/umount '/mnt/sdcard'"
+
+LABEL="sd_cards_auto_mount_end"


### PR DESCRIPTION
Read/Write filesystems are now mounted with `sync` option
to make sure no changes are lost when powering down the
system.

In addition to this, `poweroff` command is called when exiting
RetroArch, so there is a proper way of shutting down the
system, as pushing the button just cuts the power.