### PR TITLE
Add sdl2-gx dependency to openbor

### DIFF
--- a/buildroot/package/emulators/openbor/openbor6510/openbor6510.mk
+++ b/buildroot/package/emulators/openbor/openbor6510/openbor6510.mk
@@ -8,7 +8,7 @@ OPENBOR6510_VERSION = v6510-dev
 OPENBOR6510_SITE = $(call github,DCurrent,openbor,$(OPENBOR6510_VERSION))
 OPENBOR6510_LICENSE = BSD
 
-OPENBOR6510_DEPENDENCIES = libvpx sdl2 libpng libogg libvorbis host-yasm
+OPENBOR6510_DEPENDENCIES = libvpx sdl2 libpng libogg libvorbis host-yasm sdl2_gfx
 
 OPENBOR6510_EXTRAOPTS=""
 


### PR DESCRIPTION
Needed for a clean build from scratch.

Change proposed by acmeplus <acmeplus@users.noreply.github.com>