### PR TITLE
Fix links to Rockchip repositories

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -20,8 +20,8 @@ Install it at your own responsibility. **This firmware is ONLY for A12 and A13 a
 ## Windows Installation
 
 * Charge the device, it needs to be at least at 80% battery or 7 hours charged
-* Download drivers here [Rockchip repository](https://github.com/rockchip-linux/tools/blob/master/windows/DriverAssitant_v5.0.zip?raw=true)
-* Download latest RKDevTool from [RockChip repository](https://github.com/rockchip-linux/tools/blob/master/windows/RKDevTool_Release_v2.79.zip?raw=true)
+* Download [drivers from Rockchip repository](https://github.com/rockchip-linux/tools/raw/master/windows/DriverAssitant_v5.11.zip)
+* Download latest [RKDevTool from RockChip repository](https://github.com/rockchip-linux/tools/raw/master/windows/RKDevTool_Release_v2.84.zip)
   * To change the language to English, edit the config.ini file and change the value Selected=1 to Selected=2  
    ![image](https://user-images.githubusercontent.com/67930710/117533430-1509b600-afed-11eb-8424-5f40b15c60bd.png)
 
@@ -39,7 +39,7 @@ Install it at your own responsibility. **This firmware is ONLY for A12 and A13 a
 
 ## Linux Installation
 
-* Download the Linux_Upgrade_Tool from [Rockchip repository](https://github.com/rockchip-linux/tools/blob/master/linux/Linux_Upgrade_Tool/Linux_Upgrade_Tool_v1.57.zip?raw=true)
+* Download the [Linux_Upgrade_Tool from Rockchip repository](https://github.com/rockchip-linux/tools/raw/master/linux/Linux_Upgrade_Tool/Linux_Upgrade_Tool_v1.65.zip)
 * Extract the tool: ```$ unzip Linux_Upgrade_Tool_v1.57.zip```
 * Download latest custom firmware for your Powkiddy A12 / A13 from this repository
   * If you don´t know which version to install, if is an A12 is likely to rev3 and if is an A13 a rev2. **Install an incorrect version will not harm your A12/A13 system!!!**       
@@ -90,6 +90,7 @@ Upgrade firmware ok.
 
 | Modified at | Comments |Contributor |
 | ----------- | -------- | ---------- |
+| 2021-06-05  | Update links to Rockchip tools | alpgarcia |
 | 2021-05-11  | Added viewport and aspect ratio to core provided in hdmi config | fakemaria |
 | 2021-05-10  | Modified button sequence to flash the device. | fakemaria |
 | 2021-05-08  | Add audio device configuration for HDMI. | snam11 |

--- a/doc/install_es.md
+++ b/doc/install_es.md
@@ -19,8 +19,8 @@ Instálalo bajo tu completa responsabilidad. **Este firmware es SÓLAMENTE para 
 ## Instalación en Windows
 
 * El dispositivo debe de estar al 80% de carga o llevar al menos 7 horas cargando
-* Descarga los drivers de aquí [Rockchip repository](https://github.com/rockchip-linux/tools/blob/master/windows/DriverAssitant_v5.0.zip?raw=true)
-* Descarga la última versión de la RKDevTool desde aquí [RockChip repository](https://github.com/rockchip-linux/tools/blob/master/windows/RKDevTool_Release_v2.79.zip?raw=true)
+* Descarga los [drivers del repositorio de Rockchip](https://github.com/rockchip-linux/tools/raw/master/windows/DriverAssitant_v5.11.zip)
+* Descarga la última versión de la [RKDevTool desde el repositorio de RockChip](https://github.com/rockchip-linux/tools/raw/master/windows/RKDevTool_Release_v2.84.zip)
   * Para cambiar el idioma a inglés edita el fichero config.ini y cambia el valor Selected=1 a Selected=2 tal y como muestra la imagen
   * ![image](https://user-images.githubusercontent.com/67930710/117533473-4bdfcc00-afed-11eb-8f3f-42ff76de7f36.png)
  
@@ -40,7 +40,7 @@ Instálalo bajo tu completa responsabilidad. **Este firmware es SÓLAMENTE para 
 
 ## Instalación en Linux
 
-* Desgarga la utilidad Linux_Upgrade_Tool desde [Rockchip repository](https://github.com/rockchip-linux/tools/blob/master/linux/Linux_Upgrade_Tool/Linux_Upgrade_Tool_v1.57.zip?raw=true)
+* Desgarga la utilidad [Linux_Upgrade_Tool desde Rockchip repository](https://github.com/rockchip-linux/tools/raw/master/linux/Linux_Upgrade_Tool/Linux_Upgrade_Tool_v1.65.zip)
 * Extrae la utilidad: ```$ unzip Linux_Upgrade_Tool_v1.57.zip```
 * Descarga el último custom firmware para tu Powkiddy A12/A13 desde este repositorio.
   * Si no sabes que versión instalar: si es una A12 es muy probable que sea la revisión 3 y si es una A12 la revisión 2. La revisión 1 solo se vendió en los primeros meses de lanzamiento. **Instalar una versión incorrecta no dañará tu A12/A13 (por ejemplo instalar la revisión 2 en vez de la revisión 3 en una Powkiddy A12**   
@@ -91,6 +91,7 @@ Upgrade firmware ok.
 
 | Modificado el | Comentarios | Colaborador |
 | ------------- | ----------- | ----------- |
+| 2021-06-05  | Update links to rockchip tools | alpgarcia |
 | 2021-05-11  | Added viewport and aspect ratio to core provided in hdmi config | fakemaria |
 | 2021-05-10  | Modified button sequence to flash the device. | fakemaria |
 | 2021-05-08  | Add audio device configuration for HDMI. | alpgarcia |

--- a/doc/install_it.md
+++ b/doc/install_it.md
@@ -12,8 +12,8 @@ Rockchip RK3128 Custom Firmware per Powkiddy A12/A13
 **ATTENZIONE:**
 l'installazione è sotto la vostra responsabilità. **Questo firmware è SOLO per A12 e A13 (ad eccezione delle versioni con schermo IPS che non sono supportati)**, se si prova ad installarlo su altri device si andrà incontro ad un soft brick, e sarete costretti ad usare strumenti e software non forniti qui.
 * Caricate il device in modo da avere la batteria all' 80%, o tenetelo in carica per 7 ore
-* Scaricate i drivers da qui [RockChip repository](https://github.com/rockchip-linux/tools/blob/master/windows/DriverAssitant_v5.0.zip?raw=true)
-* Scaricate l'ultimo RKDevTool da [RockChip repository](https://github.com/rockchip-linux/tools/tree/master/windows)
+* Scaricate i [drivers da qui RockChip repository](https://github.com/rockchip-linux/tools/raw/master/windows/DriverAssitant_v5.11.zip)
+* Scaricate l'ultimo [RKDevTool da RockChip repository](https://github.com/rockchip-linux/tools/raw/master/windows/RKDevTool_Release_v2.84.zip)
 * Per cambiare il linguaggio in inglese, editare il file config.ini e cambiare il valore da Selected=1 a Selected=2  
    ![image](https://user-images.githubusercontent.com/67930710/117533430-1509b600-afed-11eb-8424-5f40b15c60bd.png)* Scaricate l'ultimo custom firmware per il vostro Powkiddy A12 / A13 da questa repository
   * Se non sapete che versione installare, considerate ceh se è un A12 sarà probabilmente una rev3, e se è un A13 sarà una rev2. **Installare una versione errata per il vostro device non rovinerà il vostro A12/A13 !!!**       
@@ -30,7 +30,7 @@ l'installazione è sotto la vostra responsabilità. **Questo firmware è SOLO pe
 * Cliccate sul tasto upgrade, il device farà un restart automatico e apparirà sul lato destro del software una serie di messaggi di sistema
  ![image](https://user-images.githubusercontent.com/67930710/117166887-135ea900-adc7-11eb-9b39-0c9b830b5968.png)
 
-# Modificare le configurazioni esistenti per abilitare la modalità HDMI **
+# Modificare le configurazioni esistenti per abilitare la modalità HDMI
 * Tutte le immagini dovrebbero avere 3 file di configurazione retroarch nella cartella di configurazione retroarch.cfg (retroarch.cfg,retroarch_hdmi.cfg e retroarch_v3.cfg)
 * Il sistema configurerà automaticamente la versione necessaria e faraà il boot nella modalità video più consona 
 * Connettere e disconnettere il cavo HDMI non è possibile. Per avere l'HDMI funzionante bisogna connetterlo prima di accedere il device
@@ -57,6 +57,7 @@ l'installazione è sotto la vostra responsabilità. **Questo firmware è SOLO pe
 
 | Modificado el | Comentarios | Colaborador |
 | ------------- | ----------- | ----------- |
+| 2012-06-05  | Update links to rockchip repository | alpgarcia | 
 | 2021-05-11  | Added viewport and aspect ratio to core provided in hdmi config | fakemaria |
 | 2021-05-10  | Modified button sequence to flash the device. | fakemaria |
 | 2012-05-08  | Add changelog section. | alpgarcia |


### PR DESCRIPTION
Rockchip repository structure changed. These commits fix the links from the installation guides (en, es, it) to the Rockchip repositories.

Fixes #38 