### PR TITLE
Restore S50usbdevice init script

### DIFF
--- a/buildroot/package/rockchip/rkscript/rkscript.mk
+++ b/buildroot/package/rockchip/rkscript/rkscript.mk
@@ -33,7 +33,7 @@ define RKSCRIPT_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 0755 -D $(@D)/resize-helper $(TARGET_DIR)/usr/bin/
 	$(INSTALL) -m 0755 -D $(@D)/S21mountall.sh $(TARGET_DIR)/etc/init.d/
 #	$(INSTALL) -m 0755 -D $(@D)/S22resize-disk $(TARGET_DIR)/etc/init.d/
-	$(INSTALL) -m 0755 -D $(@D)/S49usbdevice $(TARGET_DIR)/etc/init.d/
+	$(INSTALL) -m 0755 -D $(@D)/S50usbdevice $(TARGET_DIR)/etc/init.d/
 	$(INSTALL) -m 0755 -D $(@D)/S51n4 $(TARGET_DIR)/etc/init.d/
 	$(INSTALL) -m 0755 -D $(@D)/usbdevice $(TARGET_DIR)/usr/bin/
 	$(INSTALL) -m 0755 -D $(@D)/waylandtest.sh $(TARGET_DIR)/usr/bin/


### PR DESCRIPTION
It was partially moved to S49 but needed some manual
tweaks. As there is no evidence of issues with the
previous ordering this change fixes the buildroot
to avoid those manual tweaks.